### PR TITLE
Move from `bluepy` to `bleak`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,20 @@
 from setuptools import setup
 
 setup(
-    name='PySwitchmate',
-    packages=['switchmate'],
-    install_requires=['bleak'],
-    version='0.5.0',
-    description='A library to communicate with Switchmate',
-    author='Daniel Hjelseth Hoyer',
-    url='https://github.com/Danielhiversen/pySwitchmate/',
+    name="PySwitchmate",
+    packages=["switchmate"],
+    install_requires=["bleak"],
+    version="0.5.0",
+    description="A library to communicate with Switchmate",
+    author="Daniel Hjelseth Hoyer",
+    url="https://github.com/Danielhiversen/pySwitchmate/",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Environment :: Other Environment',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Topic :: Home Automation',
-        'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
+        "Development Status :: 3 - Alpha",
+        "Environment :: Other Environment",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Topic :: Home Automation",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup
 
 setup(
-    name = 'PySwitchmate',
-    packages = ['switchmate'],
+    name='PySwitchmate',
+    packages=['switchmate'],
     install_requires=['bleak'],
-    version = '0.5.0',
-    description = 'A library to communicate with Switchmate',
+    version='0.5.0',
+    description='A library to communicate with Switchmate',
     author='Daniel Hjelseth Hoyer',
     url='https://github.com/Danielhiversen/pySwitchmate/',
     classifiers=[
@@ -16,5 +16,5 @@ setup(
         'Programming Language :: Python',
         'Topic :: Home Automation',
         'Topic :: Software Development :: Libraries :: Python Modules'
-        ]
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 setup(
     name = 'PySwitchmate',
     packages = ['switchmate'],
-    install_requires=['bluepy'],
-    version = '0.4.6',
+    install_requires=['bleak'],
+    version = '0.5.0',
     description = 'A library to communicate with Switchmate',
     author='Daniel Hjelseth Hoyer',
     url='https://github.com/Danielhiversen/pySwitchmate/',

--- a/switchmate/__init__.py
+++ b/switchmate/__init__.py
@@ -28,7 +28,7 @@ class Switchmate:
     async def _connect(self) -> bool:
         # Disconnect before connecting
         if self._device is not None:
-            self._disconnect
+            await self._disconnect()
         _LOGGER.debug("Connecting")
         self._device = bleak.BleakClient(self._mac)
         try:
@@ -45,7 +45,7 @@ class Switchmate:
     async def _disconnect(self) -> None:
         _LOGGER.debug("Disconnecting")
         try:
-            self._device.disconnect()
+            await self._device.disconnect()
         except (bleak.BleakError, asyncio.exceptions.TimeoutError):
             pass
 

--- a/switchmate/__init__.py
+++ b/switchmate/__init__.py
@@ -1,10 +1,13 @@
 """Library to handle connection with Switchmate"""
 
+import asyncio
+import bleak
 import logging
 
-import bluepy
+CONNECT_LOCK = asyncio.Lock()
 
-HANDLE = 0x2e
+HANDLE = 45  # or 47 for newer "Bright" models
+
 ON_KEY = b'\x01'
 OFF_KEY = b'\x00'
 
@@ -17,62 +20,48 @@ class Switchmate:
     def __init__(self, mac, flip_on_off=False) -> None:
         self._mac = mac
         self.state = False
-        self._device = None
         self.available = False
         self._flip_on_off = flip_on_off
 
-    def _connect(self) -> bool:
-        if self._device is not None:
-            _LOGGER.debug("Disconnecting")
-            try:
-                self._device.disconnect()
-            except bluepy.btle.BTLEException:
-                pass
-        try:
-            _LOGGER.debug("Connecting")
-            self._device = bluepy.btle.Peripheral(self._mac,
-                                                  bluepy.btle.ADDR_TYPE_RANDOM)
-        except (bluepy.btle.BTLEException, BrokenPipeError):
-            _LOGGER.error("Failed to connect to switchmate",
-                          exc_info=logging.DEBUG >= _LOGGER.root.level)
-            self.available = False
-            return False
-        self.available = True
-        return True
-
-    def _sendpacket(self, key, retry=2) -> bool:
+    async def _sendpacket(self, key, retry=2) -> bool:
         try:
             _LOGGER.debug("Sending key %s", key)
-            self._device.writeCharacteristic(HANDLE, key, True)
-        except (bluepy.btle.BTLEException, BrokenPipeError):
-            if retry < 1 or not self._connect():
+            async with CONNECT_LOCK:
+                async with bleak.BleakClient(self._mac) as client:
+                    await client.write_gatt_char(HANDLE, key, True)
+        except (bleak.BleakError, asyncio.exceptions.TimeoutError):
+            if retry < 1:
                 _LOGGER.error("Cannot connect to switchmate.",
                               exc_info=logging.DEBUG >= _LOGGER.root.level)
                 self.available = False
                 return False
-            return self._sendpacket(key, retry-1)
+            return await self._sendpacket(key, retry-1)
         self.available = True
         return True
 
-    def update(self, retry=2) -> None:
+    async def update(self, retry=2) -> None:
         """Synchronize state with switch."""
         try:
             _LOGGER.debug("Updating device state.")
             key = ON_KEY if not self._flip_on_off else OFF_KEY
-            self.state = self._device.readCharacteristic(HANDLE) == key
-        except (bluepy.btle.BTLEException, AttributeError):
-            if retry < 1 or not self._connect():
+            async with CONNECT_LOCK:
+                async with bleak.BleakClient(self._mac) as client:
+                    self.state = await client.read_gatt_char(HANDLE) == key
+        except (bleak.BleakError, asyncio.exceptions.TimeoutError):
+            if retry < 1:
                 self.available = False
                 _LOGGER.error("Failed to update device state.", exc_info=True)
                 return None
-            return self.update(retry-1)
+            return await self.update(retry-1)
         self.available = True
         return None
 
-    def turn_on(self) -> bool:
+    async def turn_on(self) -> bool:
         """Turn the switch on."""
-        return self._sendpacket(ON_KEY if not self._flip_on_off else OFF_KEY)
+        return await self._sendpacket(ON_KEY if not self._flip_on_off else
+                                      OFF_KEY)
 
-    def turn_off(self) -> bool:
+    async def turn_off(self) -> bool:
         """Turn the switch off."""
-        return self._sendpacket(OFF_KEY if not self._flip_on_off else ON_KEY)
+        return await self._sendpacket(OFF_KEY if not self._flip_on_off else
+                                      ON_KEY)

--- a/switchmate/__init__.py
+++ b/switchmate/__init__.py
@@ -36,7 +36,9 @@ class Switchmate:
                 if self._handle is None:
                     # Determine handle based on Switchmate model
                     self._handle = (
-                        47 if await self._device.read_gatt_char(21) == b"Bright" else 45
+                        47
+                        if await self._device.read_gatt_char(21) == b"Bright"
+                        else 45
                     )
         except (bleak.BleakError, asyncio.exceptions.TimeoutError):
             _LOGGER.error(
@@ -72,7 +74,8 @@ class Switchmate:
                 else:
                     _LOGGER.debug("Updating Switchmate state")
                     self.state = (
-                        await self._device.read_gatt_char(self._handle) == ON_KEY
+                        await self._device.read_gatt_char(self._handle)
+                        == ON_KEY
                         if not self._flip_on_off
                         else OFF_KEY
                     )
@@ -94,8 +97,12 @@ class Switchmate:
 
     async def turn_on(self) -> bool:
         """Turn the switch on."""
-        return await self._communicate(ON_KEY if not self._flip_on_off else OFF_KEY)
+        return await self._communicate(
+            ON_KEY if not self._flip_on_off else OFF_KEY
+        )
 
     async def turn_off(self) -> bool:
         """Turn the switch off."""
-        return await self._communicate(OFF_KEY if not self._flip_on_off else ON_KEY)
+        return await self._communicate(
+            OFF_KEY if not self._flip_on_off else ON_KEY
+        )


### PR DESCRIPTION
Hi! It looks like the new Home Assistant [update](https://www.home-assistant.io/blog/2022/07/06/release-20227/) phased out `bluepy`, and, as a result, this library no longer works with Home Assistant. I am not very familiar with BLE. However, I've made some tweaks to migrate to `bleak`. Hopefully, this can help move in the right direction if not get the component back up. Thanks.