### PR TITLE
Add license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,6 @@ setup(
         "Programming Language :: Python",
         "Topic :: Home Automation",
         "Topic :: Software Development :: Libraries :: Python Modules",
+        "License :: OSI Approved :: MIT License",
     ],
 )


### PR DESCRIPTION
Hey 👋🏻,

I am currently looking into licensing in the Home Assistant project and I was noticing we could not fetch the license from this repository because the license was not set in setup.py. Could you do a release after this and maybe bump it in Home Assistant?

Thanks
